### PR TITLE
[ozone/external_wayland] Fix licenses

### DIFF
--- a/ozone/BUILD.gn
+++ b/ozone/BUILD.gn
@@ -1,4 +1,6 @@
 # Copyright (c) 2016 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
 
 config("ozone_wayland_config") {
   defines = [ "OZONE_WAYLAND_IMPLEMENTATION" ]

--- a/ozone/ui/desktop_aura/BUILD.gn
+++ b/ozone/ui/desktop_aura/BUILD.gn
@@ -1,4 +1,6 @@
-# Copyright (c) 2017 The LG Authors. All rights reserved.
+# Copyright (c) 2017 LG Electronics, Inc. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
 
 platform_list_txt_file = "$root_gen_dir/ui/ozone/platform_list.txt"
 desktop_factory_ozone_list_cc_file = "$target_gen_dir/desktop_factory_ozone_list.cc"

--- a/ozone/ui/webui/BUILD.gn
+++ b/ozone/ui/webui/BUILD.gn
@@ -1,4 +1,6 @@
 # Copyright (c) 2016 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
 
 import("//build/config/ui.gni")
 

--- a/ozone/wayland/BUILD.gn
+++ b/ozone/wayland/BUILD.gn
@@ -1,4 +1,6 @@
 # Copyright (c) 2016 The Chromium Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
 
 import("//build/config/linux/pkg_config.gni")
 

--- a/ui/platform_window/wayland_external/wayland_platform_window.h
+++ b/ui/platform_window/wayland_external/wayland_platform_window.h
@@ -1,4 +1,6 @@
-// Copyright 2017 The LG Authors. All rights reserved.
+// Copyright 2017 LG Electronics, Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef UI_PLATFORM_WINDOW_WAYLAND_EXTERNAL_WAYLAND_PLATFORM_WINDOW_H_
 #define UI_PLATFORM_WINDOW_WAYLAND_EXTERNAL_WAYLAND_PLATFORM_WINDOW_H_

--- a/ui/platform_window/wayland_external/wayland_platform_window_delegate.h
+++ b/ui/platform_window/wayland_external/wayland_platform_window_delegate.h
@@ -1,4 +1,6 @@
-// Copyright 2017 The LG Authors. All rights reserved.
+// Copyright 2017 LG Electronics, Inc. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #ifndef UI_PLATFORM_WINDOW_WAYLAND_EXTERNAL_WAYLAND_PLATFORM_WINDOW_DELEGATE_H_
 #define UI_PLATFORM_WINDOW_WAYLAND_EXTERNAL_WAYLAND_PLATFORM_WINDOW_DELEGATE_H_


### PR DESCRIPTION
All the code is released under same common BSD license of
Chromium. Explicitely state that in all the added code.